### PR TITLE
fix: reset IsCosAtlFinalized when COS is re-appointed or ATL is edited

### DIFF
--- a/IBSWeb/Areas/Filpride/Controllers/AuthorityToLoadController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/AuthorityToLoadController.cs
@@ -600,6 +600,16 @@ namespace IBSWeb.Areas.Filpride.Controllers
                         appointedSupplier.UnreservedQuantity += oldDetail.Quantity;
                         appointedSupplier.CustomerOrderSlip!.IsCosAtlFinalized = false;
                     }
+                    else
+                    {
+                        // Appointed supplier was deleted (e.g. COS was edited & re-appointed).
+                        var cos = await _dbContext.FilprideCustomerOrderSlips
+                            .FindAsync(new object[] { oldDetail.CustomerOrderSlipId }, cancellationToken);
+                        if (cos != null)
+                        {
+                            cos.IsCosAtlFinalized = false;
+                        }
+                    }
                 }
 
                 _dbContext.FilprideBookAtlDetails.RemoveRange(atl.Details);

--- a/IBSWeb/Areas/Filpride/Controllers/AuthorityToLoadController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/AuthorityToLoadController.cs
@@ -600,16 +600,6 @@ namespace IBSWeb.Areas.Filpride.Controllers
                         appointedSupplier.UnreservedQuantity += oldDetail.Quantity;
                         appointedSupplier.CustomerOrderSlip!.IsCosAtlFinalized = false;
                     }
-                    else
-                    {
-                        // Appointed supplier was deleted (e.g. COS was edited & re-appointed).
-                        var cos = await _dbContext.FilprideCustomerOrderSlips
-                            .FindAsync(new object[] { oldDetail.CustomerOrderSlipId }, cancellationToken);
-                        if (cos != null)
-                        {
-                            cos.IsCosAtlFinalized = false;
-                        }
-                    }
                 }
 
                 _dbContext.FilprideBookAtlDetails.RemoveRange(atl.Details);

--- a/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
@@ -750,6 +750,8 @@ namespace IBSWeb.Areas.Filpride.Controllers
                         await _dbContext.FilprideCOSAppointedSuppliers
                             .Where(a => a.CustomerOrderSlipId == existingRecord.CustomerOrderSlipId)
                             .ExecuteDeleteAsync(cancellationToken);
+
+                        existingRecord.IsCosAtlFinalized = false;
                     }
 
                     await _unitOfWork.Notifications.AddNotificationToMultipleUsersAsync(users, message);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when editing order and load records so related finalized flags are correctly reset in more edge cases.
  * Restored quantities and status updates now handle missing linked supplier records more safely, helping keep customer order slip status accurate.
  * Editing a customer order slip now reliably clears finalized status when the order is returned for further approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->