### PR TITLE
feat: Add marketing supervisor approval before CNC manager approval in COS + DMCM approval on Dashboard items

### DIFF
--- a/IBS.DataAccess/Migrations/20260729053925_AddMarketingApprovalToCustomerOrderSlip.Designer.cs
+++ b/IBS.DataAccess/Migrations/20260729053925_AddMarketingApprovalToCustomerOrderSlip.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IBS.DataAccess.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IBS.DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729053925_AddMarketingApprovalToCustomerOrderSlip")]
+    partial class AddMarketingApprovalToCustomerOrderSlip
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/IBS.DataAccess/Migrations/20260729053925_AddMarketingApprovalToCustomerOrderSlip.cs
+++ b/IBS.DataAccess/Migrations/20260729053925_AddMarketingApprovalToCustomerOrderSlip.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace IBS.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMarketingApprovalToCustomerOrderSlip : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "marketing_approved_by",
+                table: "filpride_customer_order_slips",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "marketing_approved_date",
+                table: "filpride_customer_order_slips",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "marketing_approved_by",
+                table: "filpride_customer_order_slips");
+
+            migrationBuilder.DropColumn(
+                name: "marketing_approved_date",
+                table: "filpride_customer_order_slips");
+        }
+    }
+}

--- a/IBS.Models/Enums/General.cs
+++ b/IBS.Models/Enums/General.cs
@@ -29,6 +29,7 @@ namespace IBS.Models.Enums
 
     public enum CosStatus
     {
+        ForApprovalOfMarketing,
         Created,
         SupplierAppointed,
         HaulerAppointed,

--- a/IBS.Models/Filpride/Integrated/FilprideCustomerOrderSlip.cs
+++ b/IBS.Models/Filpride/Integrated/FilprideCustomerOrderSlip.cs
@@ -143,6 +143,16 @@ namespace IBS.Models.Filpride.Integrated
 
         #endregion
 
+        #region Approval of Marketing
+
+        [StringLength(100)]
+        public string? MarketingApprovedBy { get; set; }
+
+        [Column(TypeName = "timestamp without time zone")]
+        public DateTime? MarketingApprovedDate { get; set; }
+
+        #endregion
+
         #region Approval of Operation Manager
 
         [StringLength(100)]

--- a/IBS.Models/Filpride/ViewModels/DashboardCountViewModel.cs
+++ b/IBS.Models/Filpride/ViewModels/DashboardCountViewModel.cs
@@ -2,6 +2,7 @@ namespace IBS.Models.Filpride.ViewModels
 {
     public class DashboardCountViewModel
     {
+        public int MarketingApprovalCount { get; set; }
         public int SupplierAppointmentCount { get; set; }
         public int HaulerAppointmentCount { get; set; }
         public int ATLBookingCount { get; set; }

--- a/IBS.Models/Filpride/ViewModels/DashboardCountViewModel.cs
+++ b/IBS.Models/Filpride/ViewModels/DashboardCountViewModel.cs
@@ -11,6 +11,8 @@ namespace IBS.Models.Filpride.ViewModels
         public int OMApprovalPOCount { get; set; }
         public int CNCApprovalCount { get; set; }
         public int FMApprovalCount { get; set; }
+        public int FMApprovalDMCount { get; set; }
+        public int FMApprovalCMCount { get; set; }
         public int DRCount { get; set; }
         public int InTransitCount { get; set; }
         public int ForInvoiceCount { get; set; }

--- a/IBSWeb/Areas/Filpride/Controllers/CreditMemoController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/CreditMemoController.cs
@@ -58,12 +58,48 @@ namespace IBSWeb.Areas.Filpride.Controllers
             return claims.FirstOrDefault(c => c.Type == "Company")?.Value;
         }
 
-        public IActionResult Index(string? view)
+        private const string FilterTypeClaimType = "CreditMemo_FilterType";
+
+        private async Task UpdateFilterTypeClaim(string filterType)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user != null)
+            {
+                var claims = await _userManager.GetClaimsAsync(user);
+                var existingClaim = claims.FirstOrDefault(c => c.Type == FilterTypeClaimType);
+                if (existingClaim != null)
+                {
+                    await _userManager.RemoveClaimAsync(user, existingClaim);
+                }
+
+                if (!string.IsNullOrEmpty(filterType))
+                {
+                    await _userManager.AddClaimAsync(user, new Claim(FilterTypeClaimType, filterType));
+                }
+            }
+        }
+
+        private async Task<string?> GetCurrentFilterType()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return null;
+            }
+
+            var claims = await _userManager.GetClaimsAsync(user);
+            return claims.FirstOrDefault(c => c.Type == FilterTypeClaimType)?.Value;
+        }
+
+        public async Task<IActionResult> Index(string? filterType, string? view)
         {
             if (view == nameof(DynamicView.CreditMemo))
             {
                 return View("ExportIndex");
             }
+
+            await UpdateFilterTypeClaim(filterType!);
+            ViewBag.FilterType = await GetCurrentFilterType();
 
             return View();
         }
@@ -74,9 +110,20 @@ namespace IBSWeb.Areas.Filpride.Controllers
             try
             {
                 var companyClaims = await GetCompanyClaimAsync();
+                var filterTypeClaim = await GetCurrentFilterType();
 
                 var creditMemos = _unitOfWork.FilprideCreditMemo
                     .GetAllQuery(x => x.Company == companyClaims);
+
+                if (!string.IsNullOrEmpty(filterTypeClaim))
+                {
+                    switch (filterTypeClaim)
+                    {
+                        case "ForFMApproval":
+                            creditMemos = creditMemos.Where(cm => cm.Status == nameof(DmCmStatus.ForApprovalOfFM));
+                            break;
+                    }
+                }
 
                 var totalRecords = await creditMemos.CountAsync(cancellationToken);
 

--- a/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
@@ -1323,7 +1323,7 @@ namespace IBSWeb.Areas.Filpride.Controllers
             }
         }
 
-        [Authorize(Roles = "OperationManager, FinanceManager, CncManager, MarketingSupervisor, Admin")]
+        [Authorize(Roles = "OperationManager, FinanceManager, CncManager, MarketingSupervisor, Admin, HeadApprover")]
         public async Task<IActionResult> Disapprove(int? id, CancellationToken cancellationToken)
         {
             if (id == null)

--- a/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
@@ -1259,6 +1259,8 @@ namespace IBSWeb.Areas.Filpride.Controllers
                     return BadRequest();
                 }
 
+                existingRecord.MarketingApprovedBy = GetUserFullName();
+                existingRecord.MarketingApprovedDate = DateTimeHelper.GetCurrentPhilippineTime();
                 existingRecord.Status = nameof(CosStatus.ForApprovalOfCNC);
                 existingRecord.Terms = terms ?? existingRecord.Terms;
                 existingRecord.FinanceInstruction = instructions;

--- a/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/CustomerOrderSlipController.cs
@@ -144,6 +144,10 @@ namespace IBSWeb.Areas.Filpride.Controllers
                                                        && cos.Status != nameof(CosStatus.Disapproved)
                                                        && cos.Status != nameof(CosStatus.Expired));
                             break;
+                        case "ForMarketingApproval":
+                            query = query.Where(cos =>
+                                cos.Status == nameof(CosStatus.ForApprovalOfMarketing));
+                            break;
                         case "ForCNCApproval":
                             query = query.Where(cos =>
                                 cos.Status == nameof(CosStatus.ForApprovalOfCNC));
@@ -359,7 +363,7 @@ namespace IBSWeb.Areas.Filpride.Controllers
                     Company = companyClaims,
                     CreatedBy = GetUserFullName(),
                     ProductId = viewModel.ProductId,
-                    Status = nameof(CosStatus.ForApprovalOfCNC),
+                    Status = nameof(CosStatus.ForApprovalOfMarketing),
                     OldCosNo = viewModel.OtcCosNo,
                     Terms = viewModel.Terms,
                     Branch = viewModel.SelectedBranch,
@@ -930,6 +934,11 @@ namespace IBSWeb.Areas.Filpride.Controllers
 
                 #endregion --Audit Trail Recording
 
+                if (customerOrderSlip.Status == nameof(CosStatus.ForApprovalOfMarketing))
+                {
+                    return View("PreviewByMarketing", model);
+                }
+
                 return View(customerOrderSlip.Status == nameof(CosStatus.ForApprovalOfCNC) ? "PreviewByCnc" : "PreviewByFinance", model);
             }
             catch (Exception ex)
@@ -1230,6 +1239,47 @@ namespace IBSWeb.Areas.Filpride.Controllers
             }
         }
 
+        [Authorize(Roles = "MarketingSupervisor, Admin, HeadApprover")]
+        public async Task<IActionResult> ApproveByMarketing(int? id, string? terms, string? instructions, CancellationToken cancellationToken)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                var existingRecord = await _unitOfWork.FilprideCustomerOrderSlip
+                    .GetAsync(cos => cos.CustomerOrderSlipId == id, cancellationToken);
+
+                if (existingRecord == null)
+                {
+                    return BadRequest();
+                }
+
+                existingRecord.Status = nameof(CosStatus.ForApprovalOfCNC);
+                existingRecord.Terms = terms ?? existingRecord.Terms;
+                existingRecord.FinanceInstruction = instructions;
+
+                FilprideAuditTrail auditTrailBook = new(GetUserFullName(), $"Approved customer order slip# {existingRecord.CustomerOrderSlipNo}", "Customer Order Slip", existingRecord.Company);
+                await _unitOfWork.FilprideAuditTrail.AddAsync(auditTrailBook, cancellationToken);
+
+                TempData["success"] = "Customer order slip approved by marketing successfully.";
+                await transaction.CommitAsync(cancellationToken);
+                return RedirectToAction(nameof(Preview), new { id });
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                TempData["error"] = ex.Message;
+                _logger.LogError(ex, "Failed to approve customer order slip. Error: {ErrorMessage}, Stack: {StackTrace}. Approved by: {UserName}",
+                    ex.Message, ex.StackTrace, _userManager.GetUserName(User));
+                return RedirectToAction(nameof(Preview), new { id });
+            }
+        }
+
         [Authorize(Roles = "CncManager, Admin, HeadApprover")]
         public async Task<IActionResult> ApproveByCnc(int? id, string? terms, string? instructions, CancellationToken cancellationToken)
         {
@@ -1273,7 +1323,7 @@ namespace IBSWeb.Areas.Filpride.Controllers
             }
         }
 
-        [Authorize(Roles = "OperationManager, FinanceManager, CncManager, Admin")]
+        [Authorize(Roles = "OperationManager, FinanceManager, CncManager, MarketingSupervisor, Admin")]
         public async Task<IActionResult> Disapprove(int? id, CancellationToken cancellationToken)
         {
             if (id == null)

--- a/IBSWeb/Areas/Filpride/Controllers/DebitMemoController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/DebitMemoController.cs
@@ -58,12 +58,48 @@ namespace IBSWeb.Areas.Filpride.Controllers
             return claims.FirstOrDefault(c => c.Type == "Company")?.Value;
         }
 
-        public IActionResult Index(string? view)
+        private const string FilterTypeClaimType = "DebitMemo_FilterType";
+
+        private async Task UpdateFilterTypeClaim(string filterType)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user != null)
+            {
+                var claims = await _userManager.GetClaimsAsync(user);
+                var existingClaim = claims.FirstOrDefault(c => c.Type == FilterTypeClaimType);
+                if (existingClaim != null)
+                {
+                    await _userManager.RemoveClaimAsync(user, existingClaim);
+                }
+
+                if (!string.IsNullOrEmpty(filterType))
+                {
+                    await _userManager.AddClaimAsync(user, new Claim(FilterTypeClaimType, filterType));
+                }
+            }
+        }
+
+        private async Task<string?> GetCurrentFilterType()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return null;
+            }
+
+            var claims = await _userManager.GetClaimsAsync(user);
+            return claims.FirstOrDefault(c => c.Type == FilterTypeClaimType)?.Value;
+        }
+
+        public async Task<IActionResult> Index(string? filterType, string? view)
         {
             if (view == nameof(DynamicView.DebitMemo))
             {
                 return View("ExportIndex");
             }
+
+            await UpdateFilterTypeClaim(filterType!);
+            ViewBag.FilterType = await GetCurrentFilterType();
 
             return View();
         }
@@ -74,9 +110,20 @@ namespace IBSWeb.Areas.Filpride.Controllers
             try
             {
                 var companyClaims = await GetCompanyClaimAsync();
+                var filterTypeClaim = await GetCurrentFilterType();
 
                 var debitMemos = _unitOfWork.FilprideDebitMemo
                     .GetAllQuery(x => x.Company == companyClaims);
+
+                if (!string.IsNullOrEmpty(filterTypeClaim))
+                {
+                    switch (filterTypeClaim)
+                    {
+                        case "ForFMApproval":
+                            debitMemos = debitMemos.Where(dm => dm.Status == nameof(DmCmStatus.ForApprovalOfFM));
+                            break;
+                    }
+                }
 
                 var totalRecords = await debitMemos.CountAsync(cancellationToken);
 

--- a/IBSWeb/Areas/Filpride/Views/CustomerOrderSlip/PreviewByMarketing.cshtml
+++ b/IBSWeb/Areas/Filpride/Views/CustomerOrderSlip/PreviewByMarketing.cshtml
@@ -218,7 +218,7 @@
         </table>
     </div>
     
-    @if (Model.UploadedFiles?.Count != 0 && Model.UploadedFiles != null)
+    @if (Model.UploadedFiles != null && Model.UploadedFiles.Count != 0)
     {
         <div class="hide-in-print px-1 row d-flex justify-content-start">
             <label class="mt-3">Attachments: </label>
@@ -334,66 +334,69 @@
             init();
         });
         
-        document.getElementById('approveButton').addEventListener('click', function () {
-            Swal.fire({
-                title: 'Choose an action',
-                text: "Approve or Disapprove the action.",
-                icon: 'question',
-                showCancelButton: true,
-                showDenyButton: true,
-                confirmButtonText: 'Approve',
-                denyButtonText: 'Disapprove',
-                cancelButtonText: 'Cancel'
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    Swal.fire({
-                        title: 'Do you want to change the terms?',
-                        text: "If yes, please select new terms. If not, submit to approve without changes.",
-                        icon: 'question',
-                        input: 'select',
-                        inputOptions: {
-                            '@SD.Terms_Cod': '@SD.Terms_Cod',
-                            '@SD.Terms_Prepaid': '@SD.Terms_Prepaid',
-                            '@SD.Terms_7d': '@SD.Terms_7d',
-                            '@SD.Terms_10d': '@SD.Terms_10d',
-                            '@SD.Terms_15d': '@SD.Terms_15d',
-                            '@SD.Terms_30d': '@SD.Terms_30d',
-                            '@SD.Terms_45d': '@SD.Terms_45d',
-                            '@SD.Terms_60d': '@SD.Terms_60d',
-                            '@SD.Terms_90d': '@SD.Terms_90d',
-                            '@SD.Terms_15pdc': '@SD.Terms_15pdc',
-                            '@SD.Terms_30pdc': '@SD.Terms_30pdc',
-                            '@SD.Terms_45pdc': '@SD.Terms_45pdc',
-                            '@SD.Terms_60pdc': '@SD.Terms_60pdc',
-                            '@SD.Terms_M15': '@SD.Terms_M15',
-                            '@SD.Terms_M29': '@SD.Terms_M29',
-                            '@SD.Terms_M30': '@SD.Terms_M30'
-                        },
-                        inputPlaceholder: 'Select terms (optional)',
-                        showCancelButton: false,
-                        confirmButtonText: 'Next'
-                    }).then((termResult) => {
-                        const selectedTerm = termResult.value || null;
-
+        const approveBtn = document.getElementById('approveButton');
+        if (approveBtn) {
+            approveBtn.addEventListener('click', function () {
+                Swal.fire({
+                    title: 'Choose an action',
+                    text: "Approve or Disapprove the action.",
+                    icon: 'question',
+                    showCancelButton: true,
+                    showDenyButton: true,
+                    confirmButtonText: 'Approve',
+                    denyButtonText: 'Disapprove',
+                    cancelButtonText: 'Cancel'
+                }).then((result) => {
+                    if (result.isConfirmed) {
                         Swal.fire({
-                            title: 'Add any instructions (optional)',
-                            input: 'textarea',
-                            inputPlaceholder: 'Enter instructions here...',
+                            title: 'Do you want to change the terms?',
+                            text: "If yes, please select new terms. If not, submit to approve without changes.",
+                            icon: 'question',
+                            input: 'select',
+                            inputOptions: {
+                                '@SD.Terms_Cod': '@SD.Terms_Cod',
+                                '@SD.Terms_Prepaid': '@SD.Terms_Prepaid',
+                                '@SD.Terms_7d': '@SD.Terms_7d',
+                                '@SD.Terms_10d': '@SD.Terms_10d',
+                                '@SD.Terms_15d': '@SD.Terms_15d',
+                                '@SD.Terms_30d': '@SD.Terms_30d',
+                                '@SD.Terms_45d': '@SD.Terms_45d',
+                                '@SD.Terms_60d': '@SD.Terms_60d',
+                                '@SD.Terms_90d': '@SD.Terms_90d',
+                                '@SD.Terms_15pdc': '@SD.Terms_15pdc',
+                                '@SD.Terms_30pdc': '@SD.Terms_30pdc',
+                                '@SD.Terms_45pdc': '@SD.Terms_45pdc',
+                                '@SD.Terms_60pdc': '@SD.Terms_60pdc',
+                                '@SD.Terms_M15': '@SD.Terms_M15',
+                                '@SD.Terms_M29': '@SD.Terms_M29',
+                                '@SD.Terms_M30': '@SD.Terms_M30'
+                            },
+                            inputPlaceholder: 'Select terms (optional)',
                             showCancelButton: false,
-                            confirmButtonText: 'Submit'
-                        }).then((instructionResult) => {
-                            const instruction = instructionResult.value || null;
-                            var url = '@Html.Raw(Url.Action("ApproveByMarketing", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId, terms = "__term__", instructions = "__instruction__" }))';
-                            url = url.replace('__term__', encodeURIComponent(selectedTerm || ''));
-                            url = url.replace('__instruction__', encodeURIComponent(instruction || ''));
-                            window.location.href = url;
+                            confirmButtonText: 'Next'
+                        }).then((termResult) => {
+                            const selectedTerm = termResult.value || null;
+
+                            Swal.fire({
+                                title: 'Add any instructions (optional)',
+                                input: 'textarea',
+                                inputPlaceholder: 'Enter instructions here...',
+                                showCancelButton: false,
+                                confirmButtonText: 'Submit'
+                            }).then((instructionResult) => {
+                                const instruction = instructionResult.value || null;
+                                var url = '@Html.Raw(Url.Action("ApproveByMarketing", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId, terms = "__term__", instructions = "__instruction__" }))';
+                                url = url.replace('__term__', encodeURIComponent(selectedTerm || ''));
+                                url = url.replace('__instruction__', encodeURIComponent(instruction || ''));
+                                window.location.href = url;
+                            });
                         });
-                    });
-                } else if (result.isDenied) {
-                    window.location.href = '@Url.Action("Disapprove", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId })';
-                }
+                    } else if (result.isDenied) {
+                        window.location.href = '@Url.Action("Disapprove", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId })';
+                    }
+                });
             });
-        });
+        }
     </script>
     
     <script>

--- a/IBSWeb/Areas/Filpride/Views/CustomerOrderSlip/PreviewByMarketing.cshtml
+++ b/IBSWeb/Areas/Filpride/Views/CustomerOrderSlip/PreviewByMarketing.cshtml
@@ -1,0 +1,420 @@
+@using IBS.Models
+@using IBS.Models.Enums
+@using IBS.Utility.Constants
+@using Microsoft.AspNetCore.Identity
+@model CustomerOrderSlipForApprovalViewModel
+@inject SignInManager<ApplicationUser> SignInManager
+
+@{
+    ViewData["Title"] = "Customer Order Slip - Preview";
+    
+    var selectedCompany = string.Empty;
+
+    if (SignInManager.IsSignedIn(User))
+    {
+        selectedCompany = User.Claims.FirstOrDefault(c => c.Type == "Company")?.Value;
+    }
+    
+    var decimalFormat = Model.CustomerOrderSlip!.Customer!.CustomerType != nameof(CustomerType.Government) ? SD.Two_Decimal_Format : SD.Four_Decimal_Format;
+}
+
+<style>
+    @@media print {
+        .hide-in-print {
+            visibility: hidden;
+        }
+    }
+</style>
+
+<div class="container mt-4">
+    @if (Model.Status == nameof(CosStatus.Disapproved))
+    {
+        <div class="disapproved-indicator" style="position: absolute; top: 200px; left: 50%; transform: translate(-50%, 0); z-index: 9999; font-size: 72px; color: red; opacity: 0.5;">
+            <b>DISAPPROVED</b>
+        </div>
+    }
+    
+    <div class="text-end">
+        <img src="~/img/Filpride-logo.png" width="130px"/>
+    </div>
+    <div class="text-center mb-4">
+        <h2><u><b>FILPRIDE RESOURCES INC.</b></u></h2>
+        <p>
+            57 Westgate Office, Sampson Road, CBD, Subic Bay Freeport Zone, Kalaklan,<br/>
+            Olongapo City, 2200 Zambales, Philippines<br/>
+            VAT Reg. TIN: 000-216-589-00000
+        </p>
+        <h3><b>CUSTOMER ORDER SLIP</b></h3>
+        <h6 class="text-end"><b>No.&nbsp;@Html.DisplayFor(model => model.CustomerOrderSlip!.CustomerOrderSlipNo)</b></h6>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-borderless">
+            <tbody>
+            <tr>
+                <td><b>Customer No:</b> @Model.CustomerOrderSlip.Customer?.CustomerCode</td>
+                <td class="text-end"><b>Date:</b> @Model.CustomerOrderSlip.Date.ToString(SD.Date_Format)</td>
+            </tr>
+            <tr>
+                <td><b>Customer Name:</b> @Model.CustomerOrderSlip.CustomerName.ToUpper()</td>
+                <td class="text-end"><b>Exp Date:</b> @Model.CustomerOrderSlip.ExpirationDate?.ToString(SD.Date_Format)</td>
+            </tr>
+            <tr>
+                <td><b>Terms:</b> @Model.CustomerOrderSlip.Terms</td>
+                <td class="text-end"><b>Customer PO#:</b> @Model.CustomerOrderSlip.CustomerPoNo</td>
+            </tr>
+            <tr>
+                <td><b>Branch:</b> @Model.CustomerOrderSlip.Branch</td>
+                <td class="text-end"><b>@Model.CustomerOrderSlip.DeliveryOption?.ToUpper()</b></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+            <tr>
+                <th>Product</th>
+                <th>Quantity</th>
+                <th>Unit</th>
+                <th>Vat</th>
+                <th>Del Price</th>
+                <th>Total Amount</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>@Model.CustomerOrderSlip.ProductName</td>
+                <td>@Model.CustomerOrderSlip.Quantity.ToString(decimalFormat)</td>
+                <td>@Model.CustomerOrderSlip.Product?.ProductUnit</td>
+                <td>@Model.VatAmount.ToString(decimalFormat)</td>
+                <td>
+                    @Html.DisplayFor(model => model.CustomerOrderSlip!.DeliveredPrice)
+                    @if (!string.IsNullOrEmpty(Model.PriceReference))
+                    {
+                        <span data-bs-toggle="tooltip" title="Updated based on price reference: @Model.PriceReference" class="text-muted ms-1">
+                            <i class="bi bi-check-circle-fill"></i>
+                        </span>
+                    }
+                </td>
+                <td>@Model.CustomerOrderSlip.TotalAmount.ToString(decimalFormat)</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <tr>
+                <td><b>REMARKS:</b> @Model.CustomerOrderSlip.Remarks.ToUpper()</td>
+            </tr>
+        </table>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+            <tr>
+                <th class="text-center table-primary" colspan="2">
+                    Net Delivered Price 
+                    <span data-bs-toggle="tooltip" title="All figures are exclusive of VAT." class="text-muted ms-1">
+                        <i class="bi bi-info-circle"></i>
+                    </span>
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td class="text-center col-6">COS Price</td><td class="col-6">@Html.DisplayFor(model => model.NetOfVatCosPrice)</td></tr>
+            <tr><td class="text-center">Product Cost</td><td>@Html.DisplayFor(model => model.NetOfVatProductCost)</td></tr>
+            <tr><td class="text-center">Freight Charge</td><td>@Html.DisplayFor(model => model.NetOfVatFreightCharge)</td></tr>
+            <tr><td class="text-center">Commission</td><td>@Html.DisplayFor(model => model.CustomerOrderSlip!.CommissionRate)</td></tr>
+            <tr><td class="text-center">Gross Margin</td><td>@Html.DisplayFor(model => model.GrossMargin)</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-responsive mb-3">
+        <table class="table table-bordered">
+            <thead>
+            <tr>
+                <th class="text-center table-secondary" colspan="2">Customer Credit Details</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td class="text-center col-6">Available Credit Limit</td><td class="col-6">@Model.AvailableCreditLimit.ToString(decimalFormat)</td></tr>
+            <tr><td class="text-center">COS Amount</td><td>@Model.CustomerOrderSlip.TotalAmount.ToString(decimalFormat)</td></tr>
+            <tr><td class="text-center">Credit Balance</td><td>@Model.Total.ToString(decimalFormat)</td></tr>
+            </tbody>
+        </table>
+    </div>
+    
+    <div class="mt-3">
+        <table class="w-100">
+            <tbody>
+            <tr>
+                <td style="width: 5%;"></td>
+                <td class="text-end" style="width: 20%;">PREPARED BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">MAG</td>
+                <td class="text-end" style="width: 20%;">CHECKED BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">JBC/JTA</td>
+                <td style="width: 15%;"></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td class="text-center">MARKETING ASSISTANT</td>
+                <td></td>
+                <td class="text-center">CNC STAFF</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    
+    <div class="mt-3">
+        <table class="w-100">
+            <tbody>
+            <tr>
+                <td style="width: 5%;"></td>
+                <td class="text-end" style="width: 20%;">ACKNOWLEDGE BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">RGB</td>
+                <td class="text-end" style="width: 20%;">ACKNOWLEDGE BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">MSA</td>
+                <td style="width: 15%;"></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td class="text-center">TNS STAFF</td>
+                <td></td>
+                <td class="text-center">CNC MANAGER</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    
+    <div class="mt-3">
+        <table class="w-100">
+            <tbody>
+            <tr>
+                <td style="width: 5%;"></td>
+                <td class="text-end" style="width: 20%;">APPROVED BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">CMA</td>
+                <td class="text-end" style="width: 20%;">APPROVED BY:</td>
+                <td class="text-center border-bottom" style="width: 20%;">JVA</td>
+                <td style="width: 15%;"></td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td class="text-center">OPERATION MANAGER</td>
+                <td></td>
+                <td class="text-center">FINANCE MANAGER</td>
+                <td></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    
+    @if (Model.UploadedFiles?.Count != 0 && Model.UploadedFiles != null)
+    {
+        <div class="hide-in-print px-1 row d-flex justify-content-start">
+            <label class="mt-3">Attachments: </label>
+        </div>
+        <div class="hide-in-print pt-2 px-1 row">
+            @foreach (var file in Model.UploadedFiles)
+            {
+                <div class="file-item d-inline-flex align-items-center mb-3 col-3">
+                    <a class="btn btn-outline-primary border shadow text-truncate" href="@file.SignedUrl" target="_blank" data-name="@file.FileName" data-url="@file.SignedUrl" title="@file.FileName">
+                        @file.FileName
+                    </a>
+                </div>
+            }
+        </div>
+    }
+
+    <div class="row pt-2">
+        @{
+            if (User.IsInRole("MarketingSupervisor") || User.IsInRole("Admin") || User.IsInRole("HeadApprover"))
+            {
+                if (Model.CustomerOrderSlip.Status == nameof(CosStatus.ForApprovalOfMarketing))
+                {
+                    <div class="col-6 col-md-3">
+                        <a id="approveButton" class="btn btn-primary form-control buttons">Action</a>
+                    </div>
+                }
+                else
+                {
+                    <div class="col-6 col-md-3">
+                        <a onclick="confirmPrint(@Model.CustomerOrderSlip.CustomerOrderSlipId)" class="btn btn-primary form-control buttons">Print</a>
+                    </div>
+                }
+            }
+            else
+            {
+                <div class="col-6 col-md-3">
+                    <a onclick="confirmPrint(@Model.CustomerOrderSlip.CustomerOrderSlipId)" class="btn btn-primary form-control buttons">Print</a>
+                </div>
+            }
+            
+        }
+
+        <div class="col-6 col-md-3">
+            <a asp-area="Filpride" asp-controller="CustomerOrderSlip" asp-route-filterType="@ViewBag.FilterType" asp-action="Index" class="btn btn-outline-primary border form-control buttons">Back to List</a>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        $(document).ready(function () {
+
+            function init() {
+                bindEvents();
+            }
+
+            function bindEvents() {
+                $(document).on('click', '.existingFile-link', showExistingUpload);
+            }
+
+            function showExistingUpload(event) {
+                const fileName = $(event.currentTarget).data('name');
+                const fileUrl = $(event.currentTarget).data('url');
+
+                Swal.fire({
+                    imageUrl: fileUrl,
+                    imageAlt: fileName,
+                    showConfirmButton: false,
+                    background: 'transparent',
+                    customClass: {
+                        popup: 'custom-image-popup'
+                    },
+                    padding: '1rem',
+                    width: '90vw',
+                    heightAuto: true,
+                    didOpen: () => {
+                        $('.swal2-image').css({
+                            'max-height': '80vh',
+                            'max-width': '100%',
+                            'height': 'auto',
+                            'width': 'auto'
+                        });
+
+                        $('#custom-swal-close').remove();
+
+                        const closeButton = $('<button>×</button>').css({
+                            position: 'fixed',
+                            top: '10px',
+                            right: '10px',
+                            zIndex: '9999',
+                            background: 'rgba(202, 25, 41, 1)',
+                            color: '#fff',
+                            border: 'none',
+                            borderRadius: '20%',
+                            width: '40px',
+                            height: '40px',
+                            fontSize: '30px',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                        }).attr('id', 'custom-swal-close').on('click', () => Swal.close());
+
+                        $('body').append(closeButton);
+                    },
+                    willClose: () => {
+                        $('#custom-swal-close').remove();
+                        URL.revokeObjectURL(fileUrl);
+                    }
+                });
+            }
+
+            init();
+        });
+        
+        document.getElementById('approveButton').addEventListener('click', function () {
+            Swal.fire({
+                title: 'Choose an action',
+                text: "Approve or Disapprove the action.",
+                icon: 'question',
+                showCancelButton: true,
+                showDenyButton: true,
+                confirmButtonText: 'Approve',
+                denyButtonText: 'Disapprove',
+                cancelButtonText: 'Cancel'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    Swal.fire({
+                        title: 'Do you want to change the terms?',
+                        text: "If yes, please select new terms. If not, submit to approve without changes.",
+                        icon: 'question',
+                        input: 'select',
+                        inputOptions: {
+                            '@SD.Terms_Cod': '@SD.Terms_Cod',
+                            '@SD.Terms_Prepaid': '@SD.Terms_Prepaid',
+                            '@SD.Terms_7d': '@SD.Terms_7d',
+                            '@SD.Terms_10d': '@SD.Terms_10d',
+                            '@SD.Terms_15d': '@SD.Terms_15d',
+                            '@SD.Terms_30d': '@SD.Terms_30d',
+                            '@SD.Terms_45d': '@SD.Terms_45d',
+                            '@SD.Terms_60d': '@SD.Terms_60d',
+                            '@SD.Terms_90d': '@SD.Terms_90d',
+                            '@SD.Terms_15pdc': '@SD.Terms_15pdc',
+                            '@SD.Terms_30pdc': '@SD.Terms_30pdc',
+                            '@SD.Terms_45pdc': '@SD.Terms_45pdc',
+                            '@SD.Terms_60pdc': '@SD.Terms_60pdc',
+                            '@SD.Terms_M15': '@SD.Terms_M15',
+                            '@SD.Terms_M29': '@SD.Terms_M29',
+                            '@SD.Terms_M30': '@SD.Terms_M30'
+                        },
+                        inputPlaceholder: 'Select terms (optional)',
+                        showCancelButton: false,
+                        confirmButtonText: 'Next'
+                    }).then((termResult) => {
+                        const selectedTerm = termResult.value || null;
+
+                        Swal.fire({
+                            title: 'Add any instructions (optional)',
+                            input: 'textarea',
+                            inputPlaceholder: 'Enter instructions here...',
+                            showCancelButton: false,
+                            confirmButtonText: 'Submit'
+                        }).then((instructionResult) => {
+                            const instruction = instructionResult.value || null;
+                            var url = '@Html.Raw(Url.Action("ApproveByMarketing", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId, terms = "__term__", instructions = "__instruction__" }))';
+                            url = url.replace('__term__', encodeURIComponent(selectedTerm || ''));
+                            url = url.replace('__instruction__', encodeURIComponent(instruction || ''));
+                            window.location.href = url;
+                        });
+                    });
+                } else if (result.isDenied) {
+                    window.location.href = '@Url.Action("Disapprove", "CustomerOrderSlip", new { area = "Filpride", id = Model.CustomerOrderSlip.CustomerOrderSlipId })';
+                }
+            });
+        });
+    </script>
+    
+    <script>
+        function confirmPrint(id)
+        {
+            const afterPrintHandler = () => {
+                window.removeEventListener('afterprint', afterPrintHandler);
+                controllerThenPrint(id);
+            };
+            
+            window.addEventListener('afterprint', afterPrintHandler);
+            window.print();
+        }
+    </script>
+    
+    <script>
+        function controllerThenPrint(id) {
+            var url = `@Url.Action("Printed", "CustomerOrderSlip", new { area = "Filpride" })/${id}`;
+            window.location.href = url; // only redirect
+        }
+    </script>
+
+    <script src="~/js/disable-dev-tools-in-print.js" asp-append-version="true"></script>
+}

--- a/IBSWeb/Areas/User/Controllers/HomeController.cs
+++ b/IBSWeb/Areas/User/Controllers/HomeController.cs
@@ -50,6 +50,11 @@ namespace IBSWeb.Areas.User.Controllers
             {
                 #region -- Filpride
 
+                MarketingApprovalCount = await _dbContext.FilprideCustomerOrderSlips
+                        .Where(cos => cos.Status == nameof(CosStatus.ForApprovalOfMarketing)
+                                      && cos.Company == companyClaims)
+                        .CountAsync(),
+
                 SupplierAppointmentCount = await _dbContext.FilprideCustomerOrderSlips
                         .Where(cos =>
                             (cos.Status == nameof(CosStatus.HaulerAppointed) || cos.Status == nameof(CosStatus.Created))

--- a/IBSWeb/Areas/User/Controllers/HomeController.cs
+++ b/IBSWeb/Areas/User/Controllers/HomeController.cs
@@ -101,6 +101,16 @@ namespace IBSWeb.Areas.User.Controllers
                                       && cos.Company == companyClaims)
                         .CountAsync(),
 
+                FMApprovalDMCount = await _dbContext.FilprideDebitMemos
+                        .Where(dm => dm.Status == nameof(DmCmStatus.ForApprovalOfFM)
+                                     && dm.Company == companyClaims)
+                        .CountAsync(),
+
+                FMApprovalCMCount = await _dbContext.FilprideCreditMemos
+                        .Where(cm => cm.Status == nameof(DmCmStatus.ForApprovalOfFM)
+                                     && cm.Company == companyClaims)
+                        .CountAsync(),
+
                 DRCount = await _dbContext.FilprideCustomerOrderSlips
                         .Where(cos => cos.Status == nameof(CosStatus.ForDR)
                                       && cos.Company == companyClaims)

--- a/IBSWeb/Areas/User/Views/Home/Index.cshtml
+++ b/IBSWeb/Areas/User/Views/Home/Index.cshtml
@@ -125,6 +125,32 @@
                             </div>
 
                             <div class="col-md-4">
+                                <a href="@Url.Action("Index", "DebitMemo", new { area = "Filpride", filterType = "ForFMApproval" })" class="text-decoration-none">
+                                    <div class="card shadow-sm h-100 border-0">
+                                        <div class="card-body text-center">
+                                            <h5 class="card-title text-dark fw-semibold">
+                                                <i class="bi bi-check-circle me-2 text-primary"></i>FM Approval (Debit Memo)
+                                            </h5>
+                                            <p class="card-text display-6 text-primary fw-bold">@Model.FMApprovalDMCount.ToString("N0")</p>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+
+                            <div class="col-md-4">
+                                <a href="@Url.Action("Index", "CreditMemo", new { area = "Filpride", filterType = "ForFMApproval" })" class="text-decoration-none">
+                                    <div class="card shadow-sm h-100 border-0">
+                                        <div class="card-body text-center">
+                                            <h5 class="card-title text-dark fw-semibold">
+                                                <i class="bi bi-check-circle me-2 text-primary"></i>FM Approval (Credit Memo)
+                                            </h5>
+                                            <p class="card-text display-6 text-primary fw-bold">@Model.FMApprovalCMCount.ToString("N0")</p>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+
+                            <div class="col-md-4">
                                 <a href="@Url.Action("Index", "CustomerOrderSlip", new { area = "Filpride", filterType = "ForFMApproval" })" class="text-decoration-none">
                                     <div class="card shadow-sm h-100 border-0">
                                         <div class="card-body text-center">

--- a/IBSWeb/Areas/User/Views/Home/Index.cshtml
+++ b/IBSWeb/Areas/User/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.Identity
 @model IBS.Models.Filpride.ViewModels.DashboardCountViewModel
 @inject SignInManager<ApplicationUser> SignInManager
 
@@ -33,6 +33,19 @@
                     <div class="mt-5">
                         <h2 class="fw-semibold text-secondary mb-4">Tasks Overview</h2>
                         <div class="row g-4">
+
+                            <div class="col-md-4">
+                                <a href="@Url.Action("Index", "CustomerOrderSlip", new { area = "Filpride", filterType = "ForMarketingApproval" })" class="text-decoration-none">
+                                    <div class="card shadow-sm h-100 border-0">
+                                        <div class="card-body text-center">
+                                            <h5 class="card-title text-dark fw-semibold">
+                                                <i class="bi bi-check-circle me-2 text-primary"></i>Marketing Approval
+                                            </h5>
+                                            <p class="card-text display-6 text-primary fw-bold">@Model.MarketingApprovalCount.ToString("N0")</p>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
 
                             <div class="col-md-4">
                                 <a href="@Url.Action("Index", "CustomerOrderSlip", new { area = "Filpride", filterType = "ForCNCApproval" })" class="text-decoration-none">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a **Marketing Approval** workflow for customer order slips, including a dedicated preview (with **DISAPPROVED** indicator), attachment viewing, and print support.
  - Added dashboard task cards for **Marketing Approval**, plus separate **FM Approval (Debit Memo)** and **FM Approval (Credit Memo)** counts.
  - Enabled marketing approval actions (approve with optional terms/instructions; disapprove) and expanded who can disapprove.
- **Improvements**
  - Updated debit/credit memo lists to remember each user’s selected **FM approval filter** and show the corresponding items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->