### PR TITLE
fix: include bank account on cv trade header report

### DIFF
--- a/IBSWeb/Areas/Filpride/Controllers/AccountsPayableReportController.cs
+++ b/IBSWeb/Areas/Filpride/Controllers/AccountsPayableReportController.cs
@@ -767,6 +767,7 @@ namespace IBSWeb.Areas.Filpride.Controllers
                                 : statusFilter != "InvalidOnly" || cvh.VoidedBy != null))
                         .Include(cvh => cvh.Details!)
                         .Include(cvh => cvh.Supplier)
+                        .Include(cvh => cvh.BankAccount)
                         .OrderBy(cvh => cvh.Date)
                         .ThenBy(cvh => cvh.CheckVoucherHeaderNo)
                         .ToListAsync(cancellationToken);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Check voucher bank account details are now included when generating Accounts Payable disbursement reports in Excel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->